### PR TITLE
Removed prevent_destroy flag from bucket

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -18,9 +18,6 @@ resource "opentelekomcloud_obs_bucket" "tf_remote_state" {
   acl        = "private"
   region     = var.region
   versioning = true
-  lifecycle {
-    prevent_destroy = true
-  }
 }
 
 resource "opentelekomcloud_obs_bucket_policy" "only_encrypted" {


### PR DESCRIPTION
The bucket resource already has protection aganist accidental deletion (it can not be removed if any object exists within the bucket). Furthermore, a public module should not have the prevent_destroy flag set unconditionally as the module code can not be modified by the user and this results in undeletable (with terraform) resources. If needed, using a conditional (and most probably optional) flag should be defined on module input to manage the prevent_destroy flags.