### PR TITLE
Feature/optional encryption policy

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -21,6 +21,7 @@ resource "opentelekomcloud_obs_bucket" "tf_remote_state" {
 }
 
 resource "opentelekomcloud_obs_bucket_policy" "only_encrypted" {
+  count  = var.force_encryption ? 1 : 0
   bucket = opentelekomcloud_obs_bucket.tf_remote_state.id
   policy = jsonencode({
     Version = "2008-10-17"

--- a/variables.tf
+++ b/variables.tf
@@ -1,4 +1,8 @@
 variable "bucket_name" {
   description = "The bucket name where the encrypted tf file should be stored"
 }
+variable "force_encryption" {
+  default = true
+  description = "Add an encryption enforcing policy to the state bucket. Default = true"
+}
 variable "region" {}

--- a/variables.tf
+++ b/variables.tf
@@ -2,7 +2,7 @@ variable "bucket_name" {
   description = "The bucket name where the encrypted tf file should be stored"
 }
 variable "force_encryption" {
-  default = true
+  default     = true
   description = "Add an encryption enforcing policy to the state bucket. Default = true"
 }
 variable "region" {}


### PR DESCRIPTION
An optional variable force_encryption is added to give the module user the ability to disable the encryption policy on the bucket to allow unencrypted writes the the bucket along with encrypted state.